### PR TITLE
Add `browser` field to `package.json` for webpack/browserify support 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "respimage",
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"browser": "respimage.dev.js",
 	"engines": {
 		"node": ">= 0.8.0"


### PR DESCRIPTION
#25 added respimage to `npm`.  Awesome, but sadly `require("respimage")` will fail unless `package.json` contains a `main` or `browser` field.

By convention, `main` is the Node-compatible build and `browser` is the browser-compatible one.  Since respimage is useless in Node, I've populated `browser`.
